### PR TITLE
Fix Maven group/artifact IDs

### DIFF
--- a/all/META-INF/vault/filter.xml
+++ b/all/META-INF/vault/filter.xml
@@ -15,5 +15,5 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <workspaceFilter version="1.0">
-    <filter root="/apps/<my-app>-packages"/>
+    <filter root="/apps/cooldrive-assets-commerce-packages"/>
 </workspaceFilter>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -22,7 +22,7 @@
     <!-- P A R E N T  P R O J E C T  D E S C R I P T I O N                      -->
     <!-- ====================================================================== -->
     <parent>
-        <groupId>com.<my-app>.commerce</groupId>
+        <groupId>com.cooldriveaemprogram.commerce</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -31,10 +31,10 @@
     <!-- ====================================================================== -->
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
-    <artifactId>com.<my-app>.commerce.all</artifactId>
+    <artifactId>cooldrive-assets-commerce.all</artifactId>
     <packaging>content-package</packaging>
-    <name>com.<my-app>.commerce - All</name>
-    <description>All modules package for com.<my-app>.commerce</description>
+    <name>cooldrive-assets-commerce - All</name>
+    <description>All modules package for com.cooldriveaemprogram.commerce</description>
 
     <!-- ====================================================================== -->
     <!-- B U I L D   D E F I N I T I O N                                        -->
@@ -50,28 +50,28 @@
                 <extensions>true</extensions>
                 <configuration>
                 <filterSource>META-INF/vault/filter.xml</filterSource>
-                    <group>com.<my-app>.commerce</group>
+                    <group>com.cooldriveaemprogram.commerce</group>
                     <packageType>container</packageType>
                     <!-- skip sub package validation for now as some vendor packages like CIF apps will not pass -->
                     <skipSubPackageValidation>true</skipSubPackageValidation>
                     <embeddeds>
                         <embedded>
-                            <groupId>com.<my-app>.commerce</groupId>
-                            <artifactId>com.<my-app>.commerce.ui.apps</artifactId>
+                            <groupId>com.cooldriveaemprogram.commerce</groupId>
+                            <artifactId>cooldrive-assets-commerce.ui.apps</artifactId>
                             <type>zip</type>
-                            <target>/apps/<my-app>-packages/application/install</target>
+                            <target>/apps/cooldrive-assets-commerce-packages/application/install</target>
                         </embedded>
                         <embedded>
-                            <groupId>com.<my-app>.commerce</groupId>
-                            <artifactId>com.<my-app>.commerce.ui.content</artifactId>
+                            <groupId>com.cooldriveaemprogram.commerce</groupId>
+                            <artifactId>cooldrive-assets-commerce.ui.content</artifactId>
                             <type>zip</type>
-                            <target>/apps/<my-app>-packages/content/install</target>
+                            <target>/apps/cooldrive-assets-commerce-packages/content/install</target>
                         </embedded>
                         <embedded>
-                            <groupId>com.<my-app>.commerce</groupId>
-                            <artifactId>com.<my-app>.commerce.ui.config</artifactId>
+                            <groupId>com.cooldriveaemprogram.commerce</groupId>
+                            <artifactId>cooldrive-assets-commerce.ui.config</artifactId>
                             <type>zip</type>
-                            <target>/apps/<my-app>-packages/application/install</target>
+                            <target>/apps/cooldrive-assets-commerce-packages/application/install</target>
                         </embedded>
                     </embeddeds>
                 </configuration>
@@ -175,20 +175,20 @@
     <!-- ====================================================================== -->
     <dependencies>
         <dependency>
-            <groupId>com.<my-app>.commerce</groupId>
-            <artifactId>com.<my-app>.commerce.ui.apps</artifactId>
+            <groupId>com.cooldriveaemprogram.commerce</groupId>
+            <artifactId>cooldrive-assets-commerce.ui.apps</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>
         <dependency>
-            <groupId>com.<my-app>.commerce</groupId>
-            <artifactId>com.<my-app>.commerce.ui.content</artifactId>
+            <groupId>com.cooldriveaemprogram.commerce</groupId>
+            <artifactId>cooldrive-assets-commerce.ui.content</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>
         <dependency>
-            <groupId>com.<my-app>.commerce</groupId>
-            <artifactId>com.<my-app>.commerce.ui.config</artifactId>
+            <groupId>com.cooldriveaemprogram.commerce</groupId>
+            <artifactId>cooldrive-assets-commerce.ui.config</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
 --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.<my-app>.commerce</groupId>
+    <groupId>com.cooldriveaemprogram.commerce</groupId>
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
     <version>0.0.1-SNAPSHOT</version>
-    <name><my-app>-commerce</name>
+    <name>cooldrive-assets-commerce</name>
     <description>parent project for aem assets and commerce rule engine integration</description>
 
     <modules>
@@ -48,7 +48,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aem.sdk.api>2023.3.11382.20230315T073850Z-230100</aem.sdk.api>
         <aemanalyser.version>1.4.10</aemanalyser.version>
-        <componentGroupName><my-app>spolarise2etest1</componentGroupName>
+        <componentGroupName>cooldriveaemprogram</componentGroupName>
     </properties>
 
     <build>

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -6,7 +6,7 @@
     <!-- P A R E N T  P R O J E C T  D E S C R I P T I O N                      -->
     <!-- ====================================================================== -->
     <parent>
-        <groupId>com.<my-app>.commerce</groupId>
+        <groupId>com.cooldriveaemprogram.commerce</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -15,9 +15,9 @@
     <!-- ====================================================================== -->
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
-    <artifactId>com.<my-app>.commerce.ui.apps.structure</artifactId>
+    <artifactId>cooldrive-assets-commerce.ui.apps.structure</artifactId>
     <packaging>content-package</packaging>
-    <name>com.<my-app>.commerce - Repository Structure Package</name>
+    <name>com.cooldriveaemprogram.commerce - Repository Structure Package</name>
     <description>
         Empty package that defines the structure of the Adobe Experience Manager repository the Code packages in this project deploy into.
         Any roots in the Code packages of this project should have their parent enumerated in the Filters list below.

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -21,7 +21,7 @@
     <!-- P A R E N T  P R O J E C T  D E S C R I P T I O N                      -->
     <!-- ====================================================================== -->
     <parent>
-        <groupId>com.<my-app>.commerce</groupId>
+        <groupId>com.cooldriveaemprogram.commerce</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -30,7 +30,7 @@
     <!-- ====================================================================== -->
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
-    <artifactId>com.<my-app>.commerce.ui.apps</artifactId>
+    <artifactId>cooldrive-assets-commerce.ui.apps</artifactId>
     <packaging>content-package</packaging>
     <name>Assets commerce integration - UI apps</name>
     <description>UI apps package for Assets commerce integration</description>
@@ -51,12 +51,12 @@
                     <properties>
                         <cloudManagerTarget>none</cloudManagerTarget>
                     </properties>
-                    <group>com.<my-app>.commerce</group>
+                    <group>com.cooldriveaemprogram.commerce</group>
                     <packageType>application</packageType>
                     <repositoryStructurePackages>
                         <repositoryStructurePackage>
-                            <groupId>com.<my-app>.commerce</groupId>
-                            <artifactId>com.<my-app>.commerce.ui.apps.structure</artifactId>
+                            <groupId>com.cooldriveaemprogram.commerce</groupId>
+                            <artifactId>cooldrive-assets-commerce.ui.apps.structure</artifactId>
                         </repositoryStructurePackage>
                     </repositoryStructurePackages>
                 </configuration>
@@ -116,8 +116,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.<my-app>.commerce</groupId>
-            <artifactId>com.<my-app>.commerce.ui.apps.structure</artifactId>
+            <groupId>com.cooldriveaemprogram.commerce</groupId>
+            <artifactId>cooldrive-assets-commerce.ui.apps.structure</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>

--- a/ui.config/pom.xml
+++ b/ui.config/pom.xml
@@ -21,7 +21,7 @@
     <!-- P A R E N T  P R O J E C T  D E S C R I P T I O N                      -->
     <!-- ====================================================================== -->
     <parent>
-        <groupId>com.<my-app>.commerce</groupId>
+        <groupId>com.cooldriveaemprogram.commerce</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -30,7 +30,7 @@
     <!-- ====================================================================== -->
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
-    <artifactId>com.<my-app>.commerce.ui.config</artifactId>
+    <artifactId>cooldrive-assets-commerce.ui.config</artifactId>
     <packaging>content-package</packaging>
     <name>Assets commerce integration - UI config</name>
     <description>config package for Assets commerce integration</description>
@@ -54,8 +54,8 @@
                     <showImportPackageReport>false</showImportPackageReport>
                     <repositoryStructurePackages>
                         <repositoryStructurePackage>
-                            <groupId>com.<my-app>.commerce</groupId>
-                            <artifactId>com.<my-app>.commerce.ui.apps.structure</artifactId>
+                            <groupId>com.cooldriveaemprogram.commerce</groupId>
+                            <artifactId>cooldrive-assets-commerce.ui.apps.structure</artifactId>
                         </repositoryStructurePackage>
                     </repositoryStructurePackages>
                 </configuration>
@@ -69,8 +69,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.<my-app>.commerce</groupId>
-            <artifactId>com.<my-app>.commerce.ui.apps.structure</artifactId>
+            <groupId>com.cooldriveaemprogram.commerce</groupId>
+            <artifactId>cooldrive-assets-commerce.ui.apps.structure</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -21,7 +21,7 @@
     <!-- P A R E N T  P R O J E C T  D E S C R I P T I O N                      -->
     <!-- ====================================================================== -->
     <parent>
-        <groupId>com.<my-app>.commerce</groupId>
+        <groupId>com.cooldriveaemprogram.commerce</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -30,7 +30,7 @@
     <!-- ====================================================================== -->
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
-    <artifactId>com.<my-app>.commerce.ui.content</artifactId>
+    <artifactId>cooldrive-assets-commerce.ui.content</artifactId>
     <packaging>content-package</packaging>
     <name>Assets commerce integration - UI content</name>
     <description>UI content package for Assets commerce integration</description>
@@ -50,7 +50,7 @@
                     <properties>
                         <cloudManagerTarget>none</cloudManagerTarget>
                     </properties>
-                    <group>com.<my-app>.commerce</group>
+                    <group>com.cooldriveaemprogram.commerce</group>
                     <packageType>content</packageType>
                     <validatorsSettings>
                         <jackrabbit-filter>


### PR DESCRIPTION
## Summary
- use new groupId and naming convention in all Maven modules
- update filter paths to match new package name

## Testing
- `mvn -q clean install` *(fails: Non-resolvable import POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68660ea36da483338098d8970be10eeb